### PR TITLE
prop type of "xs,md,sm" of Grid must be used on item

### DIFF
--- a/src/routes/Landing/index.jsx
+++ b/src/routes/Landing/index.jsx
@@ -61,7 +61,7 @@ function Landing(props) {
                     </Typography>
                 </Grid>
             </Grid>
-            <Grid container xs={9} sm={4} md={3} justify="space-around" className={classes.links}>
+            <Grid container item xs={9} sm={4} md={3} justify="space-around" className={classes.links}>
                 <a href="https://github.com/vppr" className={classes.link} target="_blank" rel="noreferrer">
                     <GitHub /> <div className={classes.linkText}>Github</div>
                 </a>


### PR DESCRIPTION
Signed-off-by: Pranav Bakre <pranavbakre@yahoo.in>